### PR TITLE
Add native backup mode, multi-destination uploads, and beginner-friendly docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,285 +1,209 @@
-# Automated cPanel Backup Script (Version 0.3)
+# cPanel Backup Script (Beginner Friendly)
 
-# UnderHost — cPanel Backup Script
+Automated backups for **normal cPanel users** (no root access required).
 
-[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
-[![ShellCheck](https://github.com/UnderHost/one-domain/actions/workflows/shellcheck.yml/badge.svg)](https://github.com/UnderHost/one-domain/actions/workflows/shellcheck.yml)
-[![Version](https://img.shields.io/badge/version-2026.0.3-green.svg)](https://github.com/UnderHost/one-domain/blob/main/docs/CHANGELOG.md)
-[![UnderHost](https://img.shields.io/badge/by-UnderHost.com-orange)](https://underhost.com)
-
-> Automated full cPanel backups via the UAPI, delivered to an FTP server or your home directory.  
-> Cron-friendly · Secure · Logged · Email notifications
+This script is designed for shared hosting accounts where:
+- You can run cron jobs in cPanel
+- Your files are outside `public_html`
+- Your host may block cPanel UAPI tokens
 
 ---
 
-## Features
+## What this script can do
 
-- **FTP or home directory** backup destinations
-- **cPanel UAPI** authentication via API tokens (no password storage)
-- **Email notifications** on success and failure
-- **Rotating log files** — configurable size and history depth
-- **Dry-run mode** — test your config without triggering a real backup
-- **Proper exit codes** — integrates cleanly with cron monitoring
-- **CLI-only execution** — cannot be triggered via a web request
+1. **Try cPanel UAPI first** (if token is available)
+2. **Fallback to native PHP backup** when UAPI is blocked
+3. Create local backup archive (`.zip` or `.tar.gz`)
+4. Upload backups to one or more destinations:
+   - Local (keep in your account)
+   - FTP
+   - SFTP (if `ssh2` extension exists)
+   - Google Drive (via `rclone`)
+   - Dropbox (via `rclone`)
+   - S3-compatible storage (via `rclone`)
+5. Send success/failure email
+6. Rotate logs and keep a limited number of local backups
 
 ---
 
 ## Requirements
 
-| Requirement | Minimum |
-|---|---|
-| PHP | 7.4+ |
-| PHP extension | `curl` |
-| cPanel | Any version supporting UAPI |
-| Access | cPanel API Token |
+- PHP 7.4+
+- cPanel cron access
+- Script stored outside `public_html`
+- Optional:
+  - `curl` extension for UAPI mode
+  - `ftp` extension for FTP upload
+  - `ssh2` extension for SFTP upload
+  - `rclone` binary for Google Drive / Dropbox / S3 (and generic cloud remotes)
 
 ---
 
-## Installation
+## Folder layout (recommended)
 
-### 1. Download the files
-
-```bash
-# Via git
-git clone https://github.com/UnderHost/cPanel-Backup.git
-cd cPanel-Backup
-
-# Or download the zip from GitHub and extract it
-```
-
-### 2. Place files outside `public_html`
-
-```
+```text
 /home/your_cpanel_user/
-├── backups/           ← store the script here, NOT inside public_html
+├── backups/
 │   ├── backup.php
-│   ├── config.php     ← your private config (never commit this)
+│   ├── config.php
 │   ├── config.php.example
-│   └── logs/          ← created automatically on first run
+│   ├── logs/
+│   ├── artifacts/
+│   └── tmp/
 └── public_html/
 ```
 
-### 3. Set permissions
+---
 
-```bash
-chmod 750 /home/your_cpanel_user/backups/
-chmod 640 /home/your_cpanel_user/backups/config.php
-```
+## Quick Start (non-technical)
 
-### 4. Configure
+### 1) Install files
+
+Upload all script files to a folder like:
+
+`/home/your_cpanel_user/backups/`
+
+> Do not place this script inside `public_html`.
+
+### 2) Configure
 
 ```bash
 cp config.php.example config.php
-nano config.php   # or edit via cPanel File Manager → Code Edit
 ```
 
-Fill in your cPanel credentials, FTP details, and notification email.  
-See [Configuration](#configuration) below for all options.
+Open `config.php` and edit:
+- `engine` (`auto` is recommended)
+- `native.home_dir`
+- `native.include_paths`
+- `native.databases` (optional but recommended)
+- `destinations`
+- notification email
 
----
-
-## Configuration
-
-Copy `config.php.example` to `config.php` and edit it:
-
-```php
-<?php
-return [
-
-    'cpanel' => [
-        'host'       => 'your-domain.com',       // cPanel hostname (no https://)
-        'user'       => 'cpanel_username',
-        'token'      => 'YOUR_API_TOKEN',         // WHM → Manage API Tokens
-        'port'       => 2083,                     // 2083 = SSL (recommended)
-        'timeout'    => 300,
-        'ssl_verify' => true,
-    ],
-
-    'backup' => [
-        'type' => 'ftp',                          // 'ftp' or 'homedir'
-    ],
-
-    'ftp' => [
-        'host'    => 'ftp.backup-server.com',
-        'user'    => 'ftp_username',
-        'pass'    => 'ftp_password',
-        'port'    => 21,
-        'path'    => '/backups',
-        'passive' => true,
-    ],
-
-    'notification' => [
-        'email' => 'admin@your-domain.com',
-        'from'  => 'backup@your-domain.com',
-    ],
-
-    'logging' => [
-        'enabled'  => true,
-        'file'     => __DIR__ . '/logs/backup.log',
-        'max_size' => 2097152,  // 2 MB before rotation
-        'keep'     => 5,        // rotated files to retain
-    ],
-
-];
-```
-
-### Generating a cPanel API Token
-
-1. Log in to **cPanel**
-2. Go to **Security → Manage API Tokens**
-3. Click **Create**
-4. Name it (e.g. `backup-script`) and click **Create**
-5. Copy the token into `config.php` → `cpanel.token`
-
-> **Tip:** Tokens are scoped per account and don't require storing your cPanel password.
-
----
-
-## Usage
-
-### Manual run
-
-```bash
-/usr/local/bin/php /home/your_cpanel_user/backups/backup.php
-```
-
-### Dry run (no backup triggered — tests config and logs only)
+### 3) Run once manually
 
 ```bash
 /usr/local/bin/php /home/your_cpanel_user/backups/backup.php --dry-run
+/usr/local/bin/php /home/your_cpanel_user/backups/backup.php
 ```
 
-### Custom config path
+### 4) Add cron job in cPanel
 
-```bash
-/usr/local/bin/php backup.php --config=/etc/mybackup/config.php
+Daily at 2 AM:
+
+```cron
+0 2 * * * /usr/local/bin/php /home/your_cpanel_user/backups/backup.php >> /dev/null 2>&1
 ```
-
-### Exit codes
-
-| Code | Meaning |
-|------|---------|
-| `0`  | Success |
-| `1`  | Failure (config error, API error, cURL error) |
 
 ---
 
-## Automation with Cron
+## Engine modes
 
-### Set up in cPanel
+### `engine = auto` (recommended)
+- Uses UAPI if available and working.
+- Automatically falls back to native backup if UAPI fails.
 
-1. Log in to cPanel → **Advanced → Cron Jobs**
-2. Add a new cron job
+### `engine = uapi`
+- Force cPanel UAPI backup trigger.
+- Fails if host blocks API token or endpoint.
 
-### Recommended schedules
-
-| Frequency | Cron expression | Notes |
-|-----------|----------------|-------|
-| Daily     | `0 2 * * *`    | Runs at 2:00 AM every day |
-| Weekly    | `0 2 * * 0`    | Runs at 2:00 AM every Sunday |
-| Monthly   | `0 2 1 * *`    | Runs at 2:00 AM on the 1st |
-
-### Cron command
-
-```
-0 2 * * *  /usr/local/bin/php /home/YOUR_USER/backups/backup.php >> /dev/null 2>&1
-```
-
-> The script writes to its own log file — piping to `/dev/null` is fine.  
-> Remove `>> /dev/null 2>&1` temporarily if you want cPanel to email you the raw output.
+### `engine = native`
+- Never calls UAPI.
+- Uses pure PHP backup logic:
+  - Copies selected folders
+  - Dumps selected MySQL databases
+  - Packages everything into one archive
 
 ---
 
-## Logs
+## Destinations
 
-Log files are written to `logs/backup.log` (relative to the script, or the absolute path in config).
+You can enable **multiple** destinations at once.
 
+### Local
+Keeps archives in `storage.local_dir`.
+
+### FTP
+Uses PHP FTP extension.
+
+### SFTP
+Uses PHP `ssh2` extension.
+
+### Google Drive / Dropbox / S3
+Uses `rclone` remote config. Set destination type to `google_drive`, `dropbox`, `s3`, or `rclone`.
+
+Example destination:
+
+```php
+[
+  'name' => 'Google Drive',
+  'type' => 'google_drive',
+  'enabled' => true,
+  'remote' => 'gdrive',
+  'path' => 'cPanel-Backups',
+]
 ```
-[2025-03-27 02:00:01] [INFO]  ════════════════════════════════════════
-[2025-03-27 02:00:01] [INFO]  UnderHost cPanel Backup — starting
-[2025-03-27 02:00:01] [INFO]  Backup type    : ftp
-[2025-03-27 02:00:01] [INFO]  Destination    : FTP (ftp.backup-server.com:21)
-[2025-03-27 02:00:02] [INFO]  Sending backup request to cPanel UAPI…
-[2025-03-27 02:00:03] [INFO]  Backup request accepted by cPanel
-[2025-03-27 02:00:03] [INFO]  Completed in 2.14s
+
+---
+
+## Database backup notes
+
+In native mode, add each database in `native.databases`:
+
+```php
+[
+  'name' => 'cpuser_wpdb',
+  'host' => 'localhost',
+  'port' => 3306,
+  'user' => 'cpuser_wpuser',
+  'pass' => 'your-db-password',
+]
 ```
 
-Logs rotate automatically when they exceed `max_size`, keeping the last `keep` copies.
+If `databases` is empty, only files are backed up.
+
+---
+
+## Logs and retention
+
+- Logs are saved to `logging.file`
+- Log rotation: `logging.max_size` + `logging.keep`
+- Local backup retention: `storage.keep_local`
 
 ---
 
 ## Troubleshooting
 
-### `Config file not found`
-```
-[FATAL] Config file not found: /home/user/backups/config.php
-```
-Run: `cp config.php.example config.php` then edit it.
+### UAPI not allowed by hosting company
+Use:
 
----
-
-### `Missing required config: cPanel API token`
-You haven't filled in `cpanel.token`. Generate one in cPanel → Security → Manage API Tokens.
-
----
-
-### `cURL error #6: Could not resolve host`
-The `cpanel.host` value is wrong or DNS is unavailable from this server.
-
----
-
-### `cPanel API returned HTTP 401`
-Your API token is invalid, expired, or the username doesn't match. Regenerate the token in cPanel.
-
----
-
-### `cURL error` — SSL issues
-If your cPanel uses a self-signed certificate, set `'ssl_verify' => false` in config.  
-Do **not** disable SSL verification on production servers unless absolutely necessary.
-
----
-
-### FTP connection issues
-- Test your FTP credentials manually with an FTP client first
-- Try `'passive' => true` (most firewalls require passive mode)
-- Check that the remote `path` exists on the FTP server
-
----
-
-## Security
-
-- **Store config outside `public_html`** — it contains credentials
-- **Set `chmod 640 config.php`** — readable only by owner and group
-- **Use API tokens** instead of cPanel passwords
-- **Keep `ssl_verify` enabled** in production
-- **Rotate FTP passwords** periodically
-- Add `config.php` and `logs/` to `.gitignore`
-
----
-
-## .gitignore
-
-```gitignore
-config.php
-logs/
-*.log
-*.log.*
+```php
+'engine' => 'native'
 ```
 
+### Google Drive / Dropbox / S3 upload fails
+- Make sure `rclone` is installed on your hosting environment
+- Confirm the remote name in config (`remote`)
+- Test command in terminal (if shell access exists):
+  `rclone lsd <remote>:`
+
+### SFTP upload fails
+Your hosting PHP may not include `ssh2` extension. Use FTP or rclone-based destination instead.
+
+### Script works manually but not in cron
+Use absolute paths in cron and config.
+
 ---
 
-## Support
+## Security tips
 
-- 📝 [Open a GitHub Issue](https://github.com/UnderHost/cPanel-Backup/issues)
-- 📧 [UnderHost Support](https://underhost.com/contact.php)
-- 🌐 [UnderHost - Managed Backup Solutions](https://underhost.com/managed-hosting.php)
+- Keep script and config outside `public_html`
+- Use file permissions: `chmod 640 config.php`
+- Use strong destination passwords
+- Do not commit real credentials to Git
+- Test restore process regularly
 
 ---
 
 ## License
 
-MIT - see [LICENSE](LICENSE) for details.
-
----
-
-*Maintained by [UnderHost](https://underhost.com) - Reliable Offshore Hosting Solutions*
+MIT

--- a/backup.php
+++ b/backup.php
@@ -1,404 +1,715 @@
 <?php
- 
+
 declare(strict_types=1);
- 
+
 /**
  * UnderHost — cPanel Backup Script
  *
- * Initiates a full cPanel backup via the UAPI and transfers it to a
- * remote FTP server or stores it in the cPanel home directory.
+ * Beginner-friendly backup runner for shared hosting.
+ * Supports:
+ * - cPanel UAPI backup trigger (when available)
+ * - Native PHP backup fallback (files + MySQL dump) when UAPI is unavailable
+ * - Upload destinations: local, FTP, SFTP, and rclone remotes (Google Drive/S3/Dropbox/etc.)
  *
- * Usage:  php backup.php [--config=/path/to/config.php] [--dry-run]
- * Cron:   0 2 * * *  /usr/local/bin/php /home/user/backups/backup.php
- *
- * @version 1.0.0
- * @link    https://github.com/UnderHost/cPanel-Backup
- * @license MIT
+ * Usage:
+ *   php backup.php [--config=/path/config.php] [--dry-run]
  */
- 
-// ─── Bootstrap ───────────────────────────────────────────────────────────────
- 
-// Ensure we are running from CLI only
+
 if (PHP_SAPI !== 'cli') {
     http_response_code(403);
     exit('This script must be run from the command line.' . PHP_EOL);
 }
- 
-// Minimum requirements check
-if (!extension_loaded('curl')) {
-    fwrite(STDERR, '[FATAL] The PHP cURL extension is required but not loaded.' . PHP_EOL);
-    exit(1);
-}
- 
+
 if (PHP_VERSION_ID < 70400) {
-    fwrite(STDERR, '[FATAL] PHP 7.4 or higher is required (current: ' . PHP_VERSION . ').' . PHP_EOL);
+    fwrite(STDERR, '[FATAL] PHP 7.4 or higher is required.' . PHP_EOL);
     exit(1);
 }
- 
-// ─── Parse CLI arguments ──────────────────────────────────────────────────────
- 
-$options    = getopt('', ['config:', 'dry-run']);
+
+$options = getopt('', ['config:', 'dry-run']);
 $configPath = $options['config'] ?? __DIR__ . '/config.php';
-$dryRun     = isset($options['dry-run']);
- 
-// ─── Load configuration ───────────────────────────────────────────────────────
- 
+$dryRun = isset($options['dry-run']);
+
 if (!file_exists($configPath)) {
     fwrite(STDERR, "[FATAL] Config file not found: {$configPath}" . PHP_EOL);
-    fwrite(STDERR, "Copy config.php.example to config.php and fill in your credentials." . PHP_EOL);
     exit(1);
 }
- 
+
 $config = require $configPath;
- 
 if (!is_array($config)) {
     fwrite(STDERR, "[FATAL] Config file must return an array." . PHP_EOL);
     exit(1);
 }
- 
-// ─── Ensure logs directory exists ────────────────────────────────────────────
- 
-$logFile = $config['logging']['file'] ?? (__DIR__ . '/logs/backup.log');
-$logDir  = dirname($logFile);
- 
+
+$defaults = [
+    'engine' => 'auto', // auto|uapi|native
+    'cpanel' => [
+        'host' => '',
+        'user' => '',
+        'token' => '',
+        'port' => 2083,
+        'timeout' => 300,
+        'ssl_verify' => true,
+    ],
+    'native' => [
+        'home_dir' => getenv('HOME') ?: dirname(__DIR__),
+        'include_paths' => ['public_html'],
+        'exclude_paths' => ['tmp', '.trash', 'logs'],
+        'databases' => [],
+    ],
+    'storage' => [
+        'local_dir' => __DIR__ . '/artifacts',
+        'temp_dir' => __DIR__ . '/tmp',
+        'keep_local' => 7,
+    ],
+    'destinations' => [
+        ['type' => 'local', 'enabled' => true],
+    ],
+    'notification' => [
+        'email' => '',
+        'from' => '',
+        'subject_success' => '[Backup] Success',
+        'subject_failure' => '[Backup] FAILED',
+    ],
+    'logging' => [
+        'enabled' => true,
+        'file' => __DIR__ . '/logs/backup.log',
+        'max_size' => 2097152,
+        'keep' => 5,
+    ],
+];
+
+$config = array_replace_recursive($defaults, $config);
+
+$logFile = $config['logging']['file'];
+$logDir = dirname($logFile);
 if (!is_dir($logDir) && !mkdir($logDir, 0750, true) && !is_dir($logDir)) {
     fwrite(STDERR, "[FATAL] Cannot create log directory: {$logDir}" . PHP_EOL);
     exit(1);
 }
- 
-// ─── Functions ────────────────────────────────────────────────────────────────
- 
-/**
- * Write a timestamped message to STDOUT and optionally to a log file.
- */
+
 function log_message(string $message, bool $isError = false): void
 {
     global $config;
- 
-    $level     = $isError ? 'ERROR' : 'INFO';
-    $timestamp = date('Y-m-d H:i:s');
-    $line      = "[{$timestamp}] [{$level}] {$message}" . PHP_EOL;
- 
-    // Write to appropriate stream
+
+    $level = $isError ? 'ERROR' : 'INFO';
+    $line = '[' . date('Y-m-d H:i:s') . "] [{$level}] {$message}" . PHP_EOL;
+
     $isError ? fwrite(STDERR, $line) : fwrite(STDOUT, $line);
- 
+
     if (!($config['logging']['enabled'] ?? true)) {
         return;
     }
- 
-    $logFile = $config['logging']['file'] ?? (__DIR__ . '/logs/backup.log');
-    $maxSize = (int)($config['logging']['max_size'] ?? 2097152);
-    $keep    = max(1, (int)($config['logging']['keep'] ?? 5));
- 
-    // Rotate if file exceeds max size
+
+    $logFile = $config['logging']['file'];
+    $maxSize = (int)$config['logging']['max_size'];
+    $keep = max(1, (int)$config['logging']['keep']);
+
     if (file_exists($logFile) && filesize($logFile) >= $maxSize) {
         rotate_logs($logFile, $keep);
     }
- 
+
     file_put_contents($logFile, $line, FILE_APPEND | LOCK_EX);
 }
- 
-/**
- * Rotate log files, keeping the last $keep copies.
- * e.g. backup.log.4 → backup.log.5, …, backup.log → backup.log.1
- */
+
 function rotate_logs(string $logFile, int $keep): void
 {
-    // Remove oldest
     $oldest = "{$logFile}.{$keep}";
     if (file_exists($oldest)) {
-        unlink($oldest);
+        @unlink($oldest);
     }
- 
-    // Shift existing rotated files
+
     for ($i = $keep - 1; $i >= 1; $i--) {
         $src = "{$logFile}.{$i}";
         $dst = "{$logFile}." . ($i + 1);
         if (file_exists($src)) {
-            rename($src, $dst);
+            @rename($src, $dst);
         }
     }
- 
-    // Rotate current log
+
     if (file_exists($logFile)) {
-        rename($logFile, "{$logFile}.1");
+        @rename($logFile, "{$logFile}.1");
     }
 }
- 
-/**
- * Send an email notification.
- * Returns true on success, false on failure.
- */
-function send_notification(string $subject, string $body): bool
+
+function send_notification(string $subject, string $body): void
 {
     global $config;
- 
-    $to   = $config['notification']['email'] ?? '';
-    $from = $config['notification']['from']  ?? "backup-noreply@{$config['cpanel']['host']}";
- 
-    if (!filter_var($to, FILTER_VALIDATE_EMAIL)) {
-        log_message("Skipping notification — invalid email address: {$to}", true);
-        return false;
+
+    $to = trim((string)($config['notification']['email'] ?? ''));
+    if ($to === '' || !filter_var($to, FILTER_VALIDATE_EMAIL)) {
+        return;
     }
- 
+
+    $from = trim((string)($config['notification']['from'] ?? ''));
     if (!filter_var($from, FILTER_VALIDATE_EMAIL)) {
-        $from = "backup-noreply@localhost";
+        $from = 'backup-noreply@localhost';
     }
- 
-    $headers  = "From: {$from}\r\n";
+
+    $headers = "From: {$from}\r\n";
     $headers .= "Reply-To: {$from}\r\n";
     $headers .= "Content-Type: text/plain; charset=UTF-8\r\n";
-    $headers .= "X-Mailer: UnderHost-Backup-Script/1.0\r\n";
- 
-    $result = mail($to, $subject, $body, $headers);
- 
-    if (!$result) {
-        log_message("Failed to send notification email to {$to}", true);
-    }
- 
-    return $result;
+
+    @mail($to, $subject, $body, $headers);
 }
- 
-/**
- * Validate that all required configuration keys are present and non-empty.
- * Returns an array of error strings (empty = config is valid).
- */
+
 function validate_config(array $config): array
 {
     $errors = [];
- 
-    $required = [
-        'cpanel.host'  => 'cPanel host',
-        'cpanel.user'  => 'cPanel username',
-        'cpanel.token' => 'cPanel API token',
-    ];
- 
-    foreach ($required as $path => $label) {
-        [$section, $key] = explode('.', $path);
-        if (empty($config[$section][$key])) {
-            $errors[] = "Missing required config: {$label} ({$path})";
-        }
+
+    if (!in_array($config['engine'], ['auto', 'uapi', 'native'], true)) {
+        $errors[] = "engine must be auto, uapi, or native";
     }
- 
-    $backupType = $config['backup']['type'] ?? 'ftp';
- 
-    if (!in_array($backupType, ['ftp', 'homedir'], true)) {
-        $errors[] = "Invalid backup type '{$backupType}'. Must be 'ftp' or 'homedir'.";
+
+    if (empty($config['destinations']) || !is_array($config['destinations'])) {
+        $errors[] = 'destinations must be a non-empty array';
     }
- 
-    if ($backupType === 'ftp') {
-        foreach (['host', 'user', 'pass'] as $key) {
-            if (empty($config['ftp'][$key])) {
-                $errors[] = "Missing required FTP config: ftp.{$key}";
-            }
-        }
-    }
- 
-    $email = $config['notification']['email'] ?? '';
-    if (!empty($email) && !filter_var($email, FILTER_VALIDATE_EMAIL)) {
-        $errors[] = "Invalid notification email: {$email}";
-    }
- 
+
     return $errors;
 }
- 
-/**
- * Execute the cPanel UAPI backup request.
- *
- * @throws RuntimeException on cURL or API error
- */
-function trigger_backup(array $config, bool $dryRun = false): array
+
+function can_use_uapi(array $config): bool
 {
-    $cpanel     = $config['cpanel'];
-    $backupType = $config['backup']['type'] ?? 'ftp';
-    $sslVerify  = (bool)($cpanel['ssl_verify'] ?? true);
- 
-    // Build the UAPI endpoint
-    if ($backupType === 'ftp') {
-        $endpoint = 'Backup/fullbackup_to_ftp';
-        $postData = [
-            'host'     => $config['ftp']['host'],
-            'username' => $config['ftp']['user'],
-            'password' => $config['ftp']['pass'],
-            'port'     => (int)($config['ftp']['port'] ?? 21),
-            'rdir'     => $config['ftp']['path'] ?? '/',
-            'passive'  => ($config['ftp']['passive'] ?? true) ? 1 : 0,
-            'email'    => $config['notification']['email'] ?? '',
-        ];
-    } else {
-        // homedir backup — no FTP params needed
-        $endpoint = 'Backup/fullbackup_to_homedir';
-        $postData = [
-            'email' => $config['notification']['email'] ?? '',
-        ];
-    }
- 
-    $url = "https://{$cpanel['host']}:{$cpanel['port']}/execute/{$endpoint}";
- 
+    return !empty($config['cpanel']['host'])
+        && !empty($config['cpanel']['user'])
+        && !empty($config['cpanel']['token'])
+        && extension_loaded('curl');
+}
+
+function trigger_uapi_homedir_backup(array $config, bool $dryRun): array
+{
+    $cpanel = $config['cpanel'];
+    $url = "https://{$cpanel['host']}:{$cpanel['port']}/execute/Backup/fullbackup_to_homedir";
+
     if ($dryRun) {
-        log_message("[DRY-RUN] Would POST to: {$url}");
-        log_message("[DRY-RUN] Payload: " . json_encode($postData, JSON_UNESCAPED_SLASHES));
-        return ['status' => 1, 'data' => [], 'errors' => [], 'dry_run' => true];
+        log_message("[DRY-RUN] UAPI request: {$url}");
+        return ['status' => 'ok', 'mode' => 'uapi', 'message' => 'Dry run'];
     }
- 
-    $curl = curl_init();
- 
-    curl_setopt_array($curl, [
-        CURLOPT_URL            => $url,
-        CURLOPT_HTTPHEADER     => [
-            "Authorization: cpanel {$cpanel['user']}:{$cpanel['token']}",
-        ],
-        CURLOPT_POST           => true,
-        CURLOPT_POSTFIELDS     => http_build_query($postData),
+
+    $ch = curl_init();
+    curl_setopt_array($ch, [
+        CURLOPT_URL => $url,
+        CURLOPT_HTTPHEADER => ["Authorization: cpanel {$cpanel['user']}:{$cpanel['token']}"] ,
+        CURLOPT_POST => true,
+        CURLOPT_POSTFIELDS => http_build_query(['email' => $config['notification']['email'] ?? '']),
         CURLOPT_RETURNTRANSFER => true,
-        CURLOPT_SSL_VERIFYPEER => $sslVerify,
-        CURLOPT_SSL_VERIFYHOST => $sslVerify ? 2 : 0,
-        CURLOPT_TIMEOUT        => (int)($cpanel['timeout'] ?? 300),
+        CURLOPT_SSL_VERIFYPEER => (bool)$cpanel['ssl_verify'],
+        CURLOPT_SSL_VERIFYHOST => (bool)$cpanel['ssl_verify'] ? 2 : 0,
+        CURLOPT_TIMEOUT => (int)$cpanel['timeout'],
         CURLOPT_CONNECTTIMEOUT => 30,
-        CURLOPT_FAILONERROR    => false, // We handle HTTP errors manually
     ]);
- 
-    $response   = curl_exec($curl);
-    $curlErrNo  = curl_errno($curl);
-    $curlErrMsg = curl_error($curl);
-    $httpCode   = curl_getinfo($curl, CURLINFO_HTTP_CODE);
- 
-    curl_close($curl);
- 
-    if ($curlErrNo !== 0) {
-        throw new RuntimeException("cURL error #{$curlErrNo}: {$curlErrMsg}");
+
+    $response = curl_exec($ch);
+    $errNo = curl_errno($ch);
+    $err = curl_error($ch);
+    $http = (int)curl_getinfo($ch, CURLINFO_HTTP_CODE);
+    curl_close($ch);
+
+    if ($errNo !== 0) {
+        throw new RuntimeException("UAPI cURL error {$errNo}: {$err}");
     }
- 
-    if ($response === false || $response === '') {
-        throw new RuntimeException("Empty response from cPanel API (HTTP {$httpCode})");
+
+    $decoded = json_decode((string)$response, true);
+    if ($http !== 200 || !is_array($decoded)) {
+        throw new RuntimeException("UAPI failed with HTTP {$http}");
     }
- 
-    $decoded = json_decode($response, true);
- 
-    if (json_last_error() !== JSON_ERROR_NONE) {
-        throw new RuntimeException(
-            "Failed to parse cPanel API response (HTTP {$httpCode}). " .
-            "Raw: " . substr($response, 0, 300)
-        );
+
+    if (!empty($decoded['errors'])) {
+        throw new RuntimeException('UAPI errors: ' . implode('; ', $decoded['errors']));
     }
- 
-    if ($httpCode !== 200) {
-        $apiErrors = implode('; ', $decoded['errors'] ?? []);
-        throw new RuntimeException("cPanel API returned HTTP {$httpCode}. Errors: {$apiErrors}");
-    }
- 
-    return $decoded;
+
+    return ['status' => 'ok', 'mode' => 'uapi', 'message' => 'Backup request accepted'];
 }
- 
-// ─── Main ─────────────────────────────────────────────────────────────────────
- 
-$startTime = microtime(true);
-$exitCode  = 0;
- 
-log_message("════════════════════════════════════════");
-log_message("UnderHost cPanel Backup — starting");
-if ($dryRun) {
-    log_message("DRY-RUN mode — no changes will be made");
+
+function resolve_path(string $homeDir, string $path): string
+{
+    if ($path === '') {
+        return $homeDir;
+    }
+
+    if ($path[0] === '/') {
+        return $path;
+    }
+
+    return rtrim($homeDir, '/') . '/' . ltrim($path, '/');
 }
- 
-try {
-    // 1. Validate configuration
-    $errors = validate_config($config);
-    if (!empty($errors)) {
-        throw new InvalidArgumentException(
-            "Configuration errors:\n  • " . implode("\n  • ", $errors)
+
+function copy_recursive(string $src, string $dst, array $exclude): void
+{
+    if (!file_exists($src)) {
+        return;
+    }
+
+    if (is_dir($src)) {
+        if (!is_dir($dst)) {
+            mkdir($dst, 0750, true);
+        }
+
+        $items = scandir($src);
+        if ($items === false) {
+            return;
+        }
+
+        foreach ($items as $item) {
+            if ($item === '.' || $item === '..') {
+                continue;
+            }
+
+            $srcPath = $src . '/' . $item;
+            foreach ($exclude as $ex) {
+                $ex = trim((string)$ex, '/');
+                if ($ex !== '' && strpos(trim($srcPath, '/'), $ex) !== false) {
+                    continue 2;
+                }
+            }
+
+            copy_recursive($srcPath, $dst . '/' . $item, $exclude);
+        }
+
+        return;
+    }
+
+    @copy($src, $dst);
+}
+
+function dump_mysql_database(array $db, string $outputFile): void
+{
+    $mysqli = @new mysqli(
+        $db['host'] ?? 'localhost',
+        $db['user'] ?? '',
+        $db['pass'] ?? '',
+        $db['name'] ?? '',
+        (int)($db['port'] ?? 3306)
+    );
+
+    if ($mysqli->connect_errno) {
+        throw new RuntimeException('MySQL connection failed for ' . ($db['name'] ?? 'unknown') . ': ' . $mysqli->connect_error);
+    }
+
+    $mysqli->set_charset('utf8mb4');
+
+    $fp = fopen($outputFile, 'wb');
+    if ($fp === false) {
+        throw new RuntimeException('Cannot write SQL dump: ' . $outputFile);
+    }
+
+    fwrite($fp, "-- SQL dump generated by backup.php\n");
+    fwrite($fp, 'SET FOREIGN_KEY_CHECKS=0;' . "\n\n");
+
+    $tablesRes = $mysqli->query('SHOW TABLES');
+    if ($tablesRes instanceof mysqli_result) {
+        while ($row = $tablesRes->fetch_array()) {
+            $table = $row[0];
+            fwrite($fp, "DROP TABLE IF EXISTS `{$table}`;\n");
+
+            $createRes = $mysqli->query("SHOW CREATE TABLE `{$table}`");
+            if ($createRes instanceof mysqli_result) {
+                $createRow = $createRes->fetch_assoc();
+                $createSql = $createRow['Create Table'] ?? '';
+                fwrite($fp, $createSql . ";\n\n");
+                $createRes->free();
+            }
+
+            $dataRes = $mysqli->query("SELECT * FROM `{$table}`");
+            if ($dataRes instanceof mysqli_result) {
+                while ($data = $dataRes->fetch_assoc()) {
+                    $cols = array_map(static fn($col) => "`{$col}`", array_keys($data));
+                    $vals = array_map(
+                        static function ($v) use ($mysqli): string {
+                            if ($v === null) {
+                                return 'NULL';
+                            }
+                            return "'" . $mysqli->real_escape_string((string)$v) . "'";
+                        },
+                        array_values($data)
+                    );
+
+                    fwrite($fp, 'INSERT INTO `' . $table . '` (' . implode(',', $cols) . ') VALUES (' . implode(',', $vals) . ");\n");
+                }
+                fwrite($fp, "\n");
+                $dataRes->free();
+            }
+        }
+        $tablesRes->free();
+    }
+
+    fwrite($fp, 'SET FOREIGN_KEY_CHECKS=1;' . "\n");
+    fclose($fp);
+    $mysqli->close();
+}
+
+function create_archive_from_directory(string $sourceDir, string $targetBase): string
+{
+    if (class_exists('ZipArchive')) {
+        $zipPath = $targetBase . '.zip';
+        $zip = new ZipArchive();
+        if ($zip->open($zipPath, ZipArchive::CREATE | ZipArchive::OVERWRITE) !== true) {
+            throw new RuntimeException('Unable to create zip archive');
+        }
+
+        $iterator = new RecursiveIteratorIterator(
+            new RecursiveDirectoryIterator($sourceDir, FilesystemIterator::SKIP_DOTS),
+            RecursiveIteratorIterator::SELF_FIRST
         );
+
+        foreach ($iterator as $file) {
+            $filePath = $file->getPathname();
+            $relPath = substr($filePath, strlen($sourceDir) + 1);
+            if ($file->isDir()) {
+                $zip->addEmptyDir($relPath);
+            } else {
+                $zip->addFile($filePath, $relPath);
+            }
+        }
+
+        $zip->close();
+        return $zipPath;
     }
- 
-    $backupType = $config['backup']['type'] ?? 'ftp';
-    $destination = $backupType === 'ftp'
-        ? "FTP ({$config['ftp']['host']}:{$config['ftp']['port']})"
-        : 'cPanel home directory';
- 
-    log_message("Backup type    : {$backupType}");
-    log_message("Destination    : {$destination}");
-    log_message("cPanel host    : {$config['cpanel']['host']}:{$config['cpanel']['port']}");
-    log_message("cPanel user    : {$config['cpanel']['user']}");
-    log_message("SSL verify     : " . ($config['cpanel']['ssl_verify'] ?? true ? 'enabled' : 'DISABLED (insecure)'));
- 
-    if (!($config['cpanel']['ssl_verify'] ?? true)) {
-        log_message("WARNING: SSL verification is disabled. This is insecure in production.", true);
+
+    $tarPath = $targetBase . '.tar';
+    $gzPath = $targetBase . '.tar.gz';
+
+    if (file_exists($tarPath)) {
+        @unlink($tarPath);
     }
- 
-    // 2. Trigger backup
-    log_message("Sending backup request to cPanel UAPI…");
-    $response = trigger_backup($config, $dryRun);
- 
-    // 3. Check API response
-    if (!empty($response['errors'])) {
-        $apiErrors = implode("\n  • ", $response['errors']);
-        throw new RuntimeException("cPanel API reported errors:\n  • {$apiErrors}");
+    if (file_exists($gzPath)) {
+        @unlink($gzPath);
     }
- 
-    $elapsed = round(microtime(true) - $startTime, 2);
- 
+
+    $phar = new PharData($tarPath);
+    $phar->buildFromDirectory($sourceDir);
+    $phar->compress(Phar::GZ);
+    unset($phar);
+
+    @unlink($tarPath);
+
+    return $gzPath;
+}
+
+function rrmdir(string $dir): void
+{
+    if (!is_dir($dir)) {
+        return;
+    }
+
+    $items = scandir($dir);
+    if ($items === false) {
+        return;
+    }
+
+    foreach ($items as $item) {
+        if ($item === '.' || $item === '..') {
+            continue;
+        }
+
+        $path = $dir . '/' . $item;
+        if (is_dir($path)) {
+            rrmdir($path);
+        } else {
+            @unlink($path);
+        }
+    }
+
+    @rmdir($dir);
+}
+
+function create_native_backup(array $config, bool $dryRun): array
+{
+    $homeDir = rtrim((string)$config['native']['home_dir'], '/');
+    $localDir = rtrim((string)$config['storage']['local_dir'], '/');
+    $tempDir = rtrim((string)$config['storage']['temp_dir'], '/');
+
+    $stamp = date('Ymd_His');
+    $baseName = ($config['cpanel']['user'] ?: 'cpanel') . '_backup_' . $stamp;
+
+    $workspace = $tempDir . '/' . $baseName;
+    $contentDir = $workspace . '/content';
+    $filesDir = $contentDir . '/files';
+    $dbDir = $contentDir . '/databases';
+
     if ($dryRun) {
-        log_message("DRY-RUN complete — no backup was actually triggered.");
-    } else {
-        log_message("Backup request accepted by cPanel (cPanel will transfer in the background).");
+        log_message('[DRY-RUN] Native mode would create archive from configured files/databases.');
+        return ['status' => 'ok', 'mode' => 'native', 'dry_run' => true];
     }
- 
-    log_message("Completed in {$elapsed}s");
-    log_message("════════════════════════════════════════");
- 
-    // 4. Success notification
-    $subject = $config['notification']['subject_success']
-        ?? '[Backup] cPanel backup completed successfully';
- 
-    $body = implode(PHP_EOL, [
-        'cPanel Backup — Success',
-        str_repeat('─', 40),
-        '',
-        "Host        : {$config['cpanel']['host']}",
-        "User        : {$config['cpanel']['user']}",
-        "Type        : {$backupType}",
-        "Destination : {$destination}",
-        "Time        : " . date('Y-m-d H:i:s'),
-        "Duration    : {$elapsed}s",
-        '',
-        'cPanel will send a separate notification when the backup transfer completes.',
-        '',
-        '─────────────────────────────────────────',
-        'UnderHost Backup Script — https://underhost.com',
-    ]);
- 
+
+    foreach ([$localDir, $tempDir, $filesDir, $dbDir] as $dir) {
+        if (!is_dir($dir) && !mkdir($dir, 0750, true) && !is_dir($dir)) {
+            throw new RuntimeException('Cannot create directory: ' . $dir);
+        }
+    }
+
+    $exclude = (array)($config['native']['exclude_paths'] ?? []);
+
+    foreach ((array)$config['native']['include_paths'] as $path) {
+        $resolved = resolve_path($homeDir, (string)$path);
+        $label = trim(str_replace('/', '_', (string)$path), '_');
+        $label = $label !== '' ? $label : 'root';
+        $target = $filesDir . '/' . $label;
+        log_message('Copying files: ' . $resolved);
+        copy_recursive($resolved, $target, $exclude);
+    }
+
+    foreach ((array)$config['native']['databases'] as $db) {
+        if (empty($db['name'])) {
+            continue;
+        }
+
+        $out = $dbDir . '/' . $db['name'] . '.sql';
+        log_message('Dumping database: ' . $db['name']);
+        dump_mysql_database($db, $out);
+    }
+
+    $manifest = [
+        'created_at' => date('c'),
+        'engine' => 'native',
+        'host' => $config['cpanel']['host'] ?? '',
+        'user' => $config['cpanel']['user'] ?? '',
+        'include_paths' => $config['native']['include_paths'],
+        'database_count' => count((array)$config['native']['databases']),
+    ];
+    file_put_contents($contentDir . '/manifest.json', json_encode($manifest, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
+
+    $archiveBase = $localDir . '/' . $baseName;
+    $archivePath = create_archive_from_directory($contentDir, $archiveBase);
+
+    rrmdir($workspace);
+
+    return [
+        'status' => 'ok',
+        'mode' => 'native',
+        'archive_path' => $archivePath,
+        'archive_size' => file_exists($archivePath) ? filesize($archivePath) : 0,
+    ];
+}
+
+function upload_via_ftp(string $filePath, array $destination, bool $dryRun): array
+{
+    if (!function_exists('ftp_connect')) {
+        throw new RuntimeException('FTP extension not available in PHP.');
+    }
+
+    $host = (string)($destination['host'] ?? '');
+    $user = (string)($destination['user'] ?? '');
+    $pass = (string)($destination['pass'] ?? '');
+    $port = (int)($destination['port'] ?? 21);
+    $remotePath = rtrim((string)($destination['path'] ?? '/'), '/');
+
+    if ($dryRun) {
+        return ['ok' => true, 'message' => "[DRY-RUN] FTP upload to {$host}{$remotePath}"];
+    }
+
+    $conn = @ftp_connect($host, $port, 30);
+    if (!$conn) {
+        throw new RuntimeException('Could not connect to FTP host: ' . $host);
+    }
+
+    if (!@ftp_login($conn, $user, $pass)) {
+        ftp_close($conn);
+        throw new RuntimeException('FTP login failed for user: ' . $user);
+    }
+
+    @ftp_pasv($conn, (bool)($destination['passive'] ?? true));
+
+    $remoteFile = $remotePath . '/' . basename($filePath);
+    if (!@ftp_put($conn, $remoteFile, $filePath, FTP_BINARY)) {
+        ftp_close($conn);
+        throw new RuntimeException('FTP upload failed: ' . $remoteFile);
+    }
+
+    ftp_close($conn);
+
+    return ['ok' => true, 'message' => 'Uploaded via FTP: ' . $remoteFile];
+}
+
+function upload_via_sftp(string $filePath, array $destination, bool $dryRun): array
+{
+    if (!function_exists('ssh2_connect')) {
+        throw new RuntimeException('ssh2 extension not available for SFTP.');
+    }
+
+    $host = (string)($destination['host'] ?? '');
+    $port = (int)($destination['port'] ?? 22);
+    $user = (string)($destination['user'] ?? '');
+    $pass = (string)($destination['pass'] ?? '');
+    $remotePath = rtrim((string)($destination['path'] ?? '/'), '/');
+
+    if ($dryRun) {
+        return ['ok' => true, 'message' => "[DRY-RUN] SFTP upload to {$host}{$remotePath}"];
+    }
+
+    $connection = @ssh2_connect($host, $port);
+    if (!$connection) {
+        throw new RuntimeException('Cannot connect to SFTP server: ' . $host);
+    }
+
+    if (!@ssh2_auth_password($connection, $user, $pass)) {
+        throw new RuntimeException('SFTP auth failed for user: ' . $user);
+    }
+
+    $sftp = @ssh2_sftp($connection);
+    if (!$sftp) {
+        throw new RuntimeException('Cannot initialize SFTP subsystem.');
+    }
+
+    $remoteFile = $remotePath . '/' . basename($filePath);
+    $stream = @fopen('ssh2.sftp://' . intval($sftp) . $remoteFile, 'w');
+    if ($stream === false) {
+        throw new RuntimeException('Cannot open remote SFTP file: ' . $remoteFile);
+    }
+
+    $data = file_get_contents($filePath);
+    if ($data === false) {
+        fclose($stream);
+        throw new RuntimeException('Cannot read local file for SFTP upload.');
+    }
+
+    fwrite($stream, $data);
+    fclose($stream);
+
+    return ['ok' => true, 'message' => 'Uploaded via SFTP: ' . $remoteFile];
+}
+
+function upload_via_rclone(string $filePath, array $destination, bool $dryRun): array
+{
+    $remote = (string)($destination['remote'] ?? '');
+    $path = trim((string)($destination['path'] ?? ''), '/');
+
+    if ($remote === '') {
+        throw new RuntimeException('rclone destination requires remote.');
+    }
+
+    $target = rtrim($remote, ':') . ':' . ($path !== '' ? '/' . $path : '');
+    $cmd = 'rclone copy ' . escapeshellarg($filePath) . ' ' . escapeshellarg($target) . ' --stats=0 --checkers=4 --transfers=1';
+
+    if ($dryRun) {
+        return ['ok' => true, 'message' => '[DRY-RUN] ' . $cmd];
+    }
+
+    exec($cmd . ' 2>&1', $out, $code);
+    if ($code !== 0) {
+        throw new RuntimeException("rclone failed ({$code}): " . implode("\n", $out));
+    }
+
+    return ['ok' => true, 'message' => 'Uploaded via rclone to ' . $target];
+}
+
+function apply_retention(string $dir, int $keep): void
+{
+    $files = glob(rtrim($dir, '/') . '/*.{zip,gz,tar}', GLOB_BRACE);
+    if (!is_array($files)) {
+        return;
+    }
+
+    usort(
+        $files,
+        static fn($a, $b) => filemtime($b) <=> filemtime($a)
+    );
+
+    if (count($files) <= $keep) {
+        return;
+    }
+
+    foreach (array_slice($files, $keep) as $old) {
+        @unlink($old);
+    }
+}
+
+$start = microtime(true);
+$exitCode = 0;
+$summary = [];
+
+log_message('════════════════════════════════════════');
+log_message('UnderHost cPanel Backup — starting');
+log_message('Engine mode: ' . $config['engine']);
+if ($dryRun) {
+    log_message('DRY-RUN mode enabled.');
+}
+
+try {
+    $errors = validate_config($config);
+    if ($errors !== []) {
+        throw new InvalidArgumentException("Configuration errors:\n - " . implode("\n - ", $errors));
+    }
+
+    $result = null;
+    $engineUsed = $config['engine'];
+
+    if ($config['engine'] === 'uapi' || ($config['engine'] === 'auto' && can_use_uapi($config))) {
+        try {
+            $result = trigger_uapi_homedir_backup($config, $dryRun);
+            $engineUsed = 'uapi';
+            $summary[] = 'UAPI backup trigger accepted by cPanel.';
+        } catch (Throwable $uapiError) {
+            if ($config['engine'] === 'uapi') {
+                throw $uapiError;
+            }
+            log_message('UAPI unavailable. Falling back to native mode: ' . $uapiError->getMessage(), true);
+            $result = create_native_backup($config, $dryRun);
+            $engineUsed = 'native';
+        }
+    } else {
+        $result = create_native_backup($config, $dryRun);
+        $engineUsed = 'native';
+    }
+
+    $archivePath = $result['archive_path'] ?? null;
+
+    if ($archivePath !== null) {
+        log_message('Created archive: ' . $archivePath);
+        $summary[] = 'Archive: ' . basename($archivePath) . ' (' . round(((int)($result['archive_size'] ?? 0)) / 1024 / 1024, 2) . ' MB)';
+
+        foreach ((array)$config['destinations'] as $idx => $destination) {
+            if (($destination['enabled'] ?? true) === false) {
+                continue;
+            }
+
+            $type = strtolower((string)($destination['type'] ?? 'local'));
+            $label = $destination['name'] ?? "destination#{$idx}";
+
+            try {
+                if ($type === 'local') {
+                    $summary[] = "{$label}: kept locally";
+                    log_message("{$label}: local destination (no upload)");
+                    continue;
+                }
+
+                if ($type === 'ftp') {
+                    $res = upload_via_ftp($archivePath, $destination, $dryRun);
+                } elseif ($type === 'sftp') {
+                    $res = upload_via_sftp($archivePath, $destination, $dryRun);
+                } elseif (in_array($type, ['rclone', 'google_drive', 'dropbox', 's3'], true)) {
+                    $res = upload_via_rclone($archivePath, $destination, $dryRun);
+                } else {
+                    throw new RuntimeException('Unsupported destination type: ' . $type);
+                }
+
+                $summary[] = "{$label}: " . $res['message'];
+                log_message("{$label}: " . $res['message']);
+            } catch (Throwable $uploadError) {
+                $summary[] = "{$label}: FAILED — " . $uploadError->getMessage();
+                log_message("{$label}: upload failed — " . $uploadError->getMessage(), true);
+            }
+        }
+
+        apply_retention((string)$config['storage']['local_dir'], (int)$config['storage']['keep_local']);
+    }
+
+    $elapsed = round(microtime(true) - $start, 2);
+    log_message("Backup completed in {$elapsed}s using {$engineUsed} mode.");
+    log_message('════════════════════════════════════════');
+
+    $subject = (string)$config['notification']['subject_success'];
+    $body = "Backup completed successfully\n\n" . implode("\n", $summary) . "\n\nTime: " . date('Y-m-d H:i:s');
     send_notification($subject, $body);
- 
 } catch (Throwable $e) {
     $exitCode = 1;
-    $elapsed  = round(microtime(true) - $startTime, 2);
-    $errorMsg = $e->getMessage();
- 
-    log_message("BACKUP FAILED: {$errorMsg}", true);
+    $elapsed = round(microtime(true) - $start, 2);
+    log_message('BACKUP FAILED: ' . $e->getMessage(), true);
     log_message("Failed after {$elapsed}s", true);
-    log_message("════════════════════════════════════════");
- 
-    $subject = $config['notification']['subject_failure']
-        ?? '[Backup] ALERT — cPanel backup failed';
- 
-    $body = implode(PHP_EOL, [
-        'cPanel Backup — FAILED',
-        str_repeat('─', 40),
-        '',
-        "Host  : {$config['cpanel']['host']}",
-        "User  : {$config['cpanel']['user']}",
-        "Time  : " . date('Y-m-d H:i:s'),
-        '',
-        'Error:',
-        $errorMsg,
-        '',
-        'Please check the backup log for details.',
-        '',
-        '─────────────────────────────────────────',
-        'UnderHost Backup Script — https://underhost.com',
-    ]);
- 
+    log_message('════════════════════════════════════════');
+
+    $subject = (string)$config['notification']['subject_failure'];
+    $body = "Backup failed\n\nError:\n" . $e->getMessage() . "\n\nTime: " . date('Y-m-d H:i:s');
     send_notification($subject, $body);
 }
- 
+
 exit($exitCode);

--- a/config.php
+++ b/config.php
@@ -1,82 +1,141 @@
 <?php
 
 /**
- * cPanel Backup — Configuration File
+ * Beginner-friendly config for backup.php
  *
- * Copy this file to config.php and fill in your values.
- * NEVER commit config.php to version control — add it to .gitignore.
- *
- * Permissions: chmod 640 config.php
+ * 1) Copy this file to config.php
+ * 2) Fill only what you need
+ * 3) Keep config.php private (chmod 640)
  */
 
 return [
 
-    // ─── cPanel ──────────────────────────────────────────────────────────────
+    // auto  = try UAPI, fallback to native backup
+    // uapi  = force cPanel UAPI only
+    // native = force PHP-only backup (works when UAPI is blocked)
+    'engine' => 'auto',
+
     'cpanel' => [
-        // Your cPanel hostname or server IP (no trailing slash, no https://)
-        'host'    => 'your-domain.com',
-
-        // cPanel username
-        'user'    => 'cpanel_username',
-
-        // cPanel API Token (WHM → Manage API Tokens → Generate Token)
-        // Recommended scopes: Backup/fullbackup_to_ftp or Backup/fullbackup_to_homedir
-        'token'   => 'YOUR_CPANEL_API_TOKEN_HERE',
-
-        // cPanel HTTPS port (2083 = SSL, 2082 = non-SSL — SSL strongly recommended)
-        'port'    => 2083,
-
-        // Request timeout in seconds (large accounts may need 300+)
-        'timeout' => 300,
-
-        // Set to true only if cPanel uses a self-signed / untrusted certificate.
-        // Leave false in production — disabling SSL verification is a security risk.
+        'host'       => 'your-domain.com',
+        'user'       => 'cpanel_username',
+        'token'      => '', // leave empty if host blocks UAPI
+        'port'       => 2083,
+        'timeout'    => 300,
         'ssl_verify' => true,
     ],
 
-    // ─── Backup Destination ──────────────────────────────────────────────────
-    'backup' => [
-        // Destination type: 'ftp' or 'homedir'
-        //   ftp     – transfers the backup to a remote FTP server (see 'ftp' section)
-        //   homedir – stores the backup in your cPanel home directory
-        'type' => 'ftp',
+    // Used only in native mode (or when auto falls back to native)
+    'native' => [
+        // Usually /home/your_cpanel_user
+        'home_dir'      => '/home/your_cpanel_user',
+
+        // Folders/files to include (relative to home_dir or absolute path)
+        'include_paths' => [
+            'public_html',
+            // 'mail',
+        ],
+
+        // Skip heavy/unneeded folders
+        'exclude_paths' => [
+            'tmp',
+            '.trash',
+            'logs',
+        ],
+
+        // Optional database dumps
+        // Add one entry per DB if you want SQL backups
+        'databases' => [
+            // [
+            //     'name' => 'cpuser_wpdb',
+            //     'host' => 'localhost',
+            //     'port' => 3306,
+            //     'user' => 'cpuser_wpuser',
+            //     'pass' => 'strong-password',
+            // ],
+        ],
     ],
 
-    // ─── FTP (used when backup.type = 'ftp') ─────────────────────────────────
-    'ftp' => [
-        'host'    => 'ftp.backup-server.com',
-        'user'    => 'ftp_username',
-        'pass'    => 'ftp_password',
-        'port'    => 21,
-        'path'    => '/backups',      // Remote directory — must exist on FTP server
-        'passive' => true,            // Passive mode — recommended behind firewalls
+    'storage' => [
+        // Local backup files are created here first
+        'local_dir'   => __DIR__ . '/artifacts',
+        'temp_dir'    => __DIR__ . '/tmp',
+        'keep_local'  => 7,
     ],
 
-    // ─── Notifications ───────────────────────────────────────────────────────
+    // You can use one or many destinations.
+    // Supported types: local, ftp, sftp, rclone, google_drive, dropbox, s3
+    // google_drive/dropbox/s3 use rclone internally.
+    'destinations' => [
+        [
+            'name'    => 'Local archive',
+            'type'    => 'local',
+            'enabled' => true,
+        ],
+
+        // FTP destination
+        // [
+        //     'name'    => 'Remote FTP',
+        //     'type'    => 'ftp',
+        //     'enabled' => false,
+        //     'host'    => 'ftp.example.com',
+        //     'port'    => 21,
+        //     'user'    => 'ftp_user',
+        //     'pass'    => 'ftp_password',
+        //     'path'    => '/backups',
+        //     'passive' => true,
+        // ],
+
+        // SFTP destination (requires PHP ssh2 extension)
+        // [
+        //     'name'    => 'Remote SFTP',
+        //     'type'    => 'sftp',
+        //     'enabled' => false,
+        //     'host'    => 'sftp.example.com',
+        //     'port'    => 22,
+        //     'user'    => 'sftp_user',
+        //     'pass'    => 'sftp_password',
+        //     'path'    => '/backups',
+        // ],
+
+        // Google Drive via rclone remote named "gdrive"
+        // [
+        //     'name'    => 'Google Drive',
+        //     'type'    => 'google_drive',
+        //     'enabled' => false,
+        //     'remote'  => 'gdrive',
+        //     'path'    => 'cPanel-Backups',
+        // ],
+
+        // Dropbox via rclone remote named "dropbox"
+        // [
+        //     'name'    => 'Dropbox',
+        //     'type'    => 'dropbox',
+        //     'enabled' => false,
+        //     'remote'  => 'dropbox',
+        //     'path'    => 'cPanel-Backups',
+        // ],
+
+        // S3 via rclone remote named "s3"
+        // [
+        //     'name'    => 'Amazon S3',
+        //     'type'    => 's3',
+        //     'enabled' => false,
+        //     'remote'  => 's3',
+        //     'path'    => 'my-bucket/cpanel-backups',
+        // ],
+    ],
+
     'notification' => [
-        // Email address to receive success/failure reports
         'email'           => 'admin@your-domain.com',
-
-        // Sender address (must be a valid address on this server to pass SPF/DKIM)
         'from'            => 'backup@your-domain.com',
-
         'subject_success' => '[Backup] cPanel backup completed successfully',
         'subject_failure' => '[Backup] ALERT — cPanel backup failed',
     ],
 
-    // ─── Logging ─────────────────────────────────────────────────────────────
     'logging' => [
         'enabled'  => true,
-
-        // Absolute path is strongly recommended so cron jobs write to the right place.
-        // Example: '/home/cpanel_username/backup_logs/backup.log'
-        // Defaults to the directory this config lives in if left as a relative path.
         'file'     => __DIR__ . '/logs/backup.log',
-
-        // Maximum log file size in bytes before rotation (default 2 MB)
         'max_size' => 2097152,
-
-        // How many rotated log files to keep (e.g. backup.log.1, backup.log.2 …)
         'keep'     => 5,
     ],
 

--- a/config.php.example
+++ b/config.php.example
@@ -1,36 +1,128 @@
 <?php
 
 /**
- * cPanel Backup — Example Configuration
+ * Beginner-friendly config for backup.php
  *
- * COPY THIS FILE to config.php and fill in your values.
- * Do NOT commit config.php to version control.
- *
- * chmod 640 config.php
+ * 1) Copy this file to config.php
+ * 2) Fill only what you need
+ * 3) Keep config.php private (chmod 640)
  */
 
 return [
 
+    // auto  = try UAPI, fallback to native backup
+    // uapi  = force cPanel UAPI only
+    // native = force PHP-only backup (works when UAPI is blocked)
+    'engine' => 'auto',
+
     'cpanel' => [
-        'host'       => 'your-domain.com',           // cPanel hostname (no https://)
+        'host'       => 'your-domain.com',
         'user'       => 'cpanel_username',
-        'token'      => 'YOUR_CPANEL_API_TOKEN_HERE', // WHM → Manage API Tokens
-        'port'       => 2083,                         // 2083 = SSL (recommended)
+        'token'      => '', // leave empty if host blocks UAPI
+        'port'       => 2083,
         'timeout'    => 300,
-        'ssl_verify' => true,                         // Set false only for self-signed certs
+        'ssl_verify' => true,
     ],
 
-    'backup' => [
-        'type' => 'ftp',  // 'ftp' or 'homedir'
+    // Used only in native mode (or when auto falls back to native)
+    'native' => [
+        // Usually /home/your_cpanel_user
+        'home_dir'      => '/home/your_cpanel_user',
+
+        // Folders/files to include (relative to home_dir or absolute path)
+        'include_paths' => [
+            'public_html',
+            // 'mail',
+        ],
+
+        // Skip heavy/unneeded folders
+        'exclude_paths' => [
+            'tmp',
+            '.trash',
+            'logs',
+        ],
+
+        // Optional database dumps
+        // Add one entry per DB if you want SQL backups
+        'databases' => [
+            // [
+            //     'name' => 'cpuser_wpdb',
+            //     'host' => 'localhost',
+            //     'port' => 3306,
+            //     'user' => 'cpuser_wpuser',
+            //     'pass' => 'strong-password',
+            // ],
+        ],
     ],
 
-    'ftp' => [
-        'host'    => 'ftp.backup-server.com',
-        'user'    => 'ftp_username',
-        'pass'    => 'ftp_password',
-        'port'    => 21,
-        'path'    => '/backups',
-        'passive' => true,
+    'storage' => [
+        // Local backup files are created here first
+        'local_dir'   => __DIR__ . '/artifacts',
+        'temp_dir'    => __DIR__ . '/tmp',
+        'keep_local'  => 7,
+    ],
+
+    // You can use one or many destinations.
+    // Supported types: local, ftp, sftp, rclone, google_drive, dropbox, s3
+    // google_drive/dropbox/s3 use rclone internally.
+    'destinations' => [
+        [
+            'name'    => 'Local archive',
+            'type'    => 'local',
+            'enabled' => true,
+        ],
+
+        // FTP destination
+        // [
+        //     'name'    => 'Remote FTP',
+        //     'type'    => 'ftp',
+        //     'enabled' => false,
+        //     'host'    => 'ftp.example.com',
+        //     'port'    => 21,
+        //     'user'    => 'ftp_user',
+        //     'pass'    => 'ftp_password',
+        //     'path'    => '/backups',
+        //     'passive' => true,
+        // ],
+
+        // SFTP destination (requires PHP ssh2 extension)
+        // [
+        //     'name'    => 'Remote SFTP',
+        //     'type'    => 'sftp',
+        //     'enabled' => false,
+        //     'host'    => 'sftp.example.com',
+        //     'port'    => 22,
+        //     'user'    => 'sftp_user',
+        //     'pass'    => 'sftp_password',
+        //     'path'    => '/backups',
+        // ],
+
+        // Google Drive via rclone remote named "gdrive"
+        // [
+        //     'name'    => 'Google Drive',
+        //     'type'    => 'google_drive',
+        //     'enabled' => false,
+        //     'remote'  => 'gdrive',
+        //     'path'    => 'cPanel-Backups',
+        // ],
+
+        // Dropbox via rclone remote named "dropbox"
+        // [
+        //     'name'    => 'Dropbox',
+        //     'type'    => 'dropbox',
+        //     'enabled' => false,
+        //     'remote'  => 'dropbox',
+        //     'path'    => 'cPanel-Backups',
+        // ],
+
+        // S3 via rclone remote named "s3"
+        // [
+        //     'name'    => 'Amazon S3',
+        //     'type'    => 's3',
+        //     'enabled' => false,
+        //     'remote'  => 's3',
+        //     'path'    => 'my-bucket/cpanel-backups',
+        // ],
     ],
 
     'notification' => [
@@ -43,7 +135,7 @@ return [
     'logging' => [
         'enabled'  => true,
         'file'     => __DIR__ . '/logs/backup.log',
-        'max_size' => 2097152, // 2 MB
+        'max_size' => 2097152,
         'keep'     => 5,
     ],
 


### PR DESCRIPTION
### Motivation
- Provide a reliable fallback for shared hosting where cPanel UAPI or API tokens may be blocked by hosting providers.
- Make the project easier for non-root / beginner users by simplifying configuration, adding local-first behavior, and documenting common workflows.
- Support more flexible backup destinations and retention so users can keep archives locally or push them to FTP/SFTP/rclone remotes.

### Description
- Rewrote `backup.php` to introduce an `engine` setting (`auto|uapi|native`) with automatic fallback to a native PHP backup when UAPI is unavailable, including file copy, MySQL dump, manifest creation, archive generation, and cleanup.
- Added upload drivers for `ftp`, `sftp`, and `rclone` (Google Drive/Dropbox/S3 via rclone), local retention management, log rotation, and improved error handling and notifications.
- Updated `config.php` and `config.php.example` to a more beginner-friendly schema (storage, native settings, `destinations` array, and sane defaults) and improved validation in the runner.
- Rewrote README to match the new usage, folder layout, engine modes, destinations, quick start steps, and troubleshooting tips.

### Testing
- Performed PHP syntax checks on modified files using `php -l` which passed for `backup.php`, `config.php`, and `config.php.example`.
- Executed a dry-run of the runner with the example config using `php backup.php --dry-run --config=config.php.example`, which completed successfully and produced expected dry-run logs.

------
